### PR TITLE
Fix 4 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/sparkjava-mysql/backend/pom.xml
+++ b/sparkjava-mysql/backend/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.16</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.4</version>
+            <version>2.8.9</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Thu, 21 Dec 2023 11:58:30 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | django/app/requirements.txt | django | [CVE-2023-31047](https://nvd.nist.gov/vuln/detail/CVE-2023-31047) | 9.8 | fixed in 4.2.1, 4.1.9, 3.2.19 | In Django 3.2 before 3.2.19, 4.x before 4.1.9, and 4.2 before 4.2.1, it was possible to bypass validation when using one form field to upload multiple files. This multiple upload has never been supported by forms.FileField or forms.ImageField (only the last uploaded file was validated). However, Django\'s \"Uploading multiple files\" documentation suggested otherwise.
critical | django/app/requirements.txt | django | [CVE-2022-34265](https://nvd.nist.gov/vuln/detail/CVE-2022-34265) | 9.8 | fixed in 4.0.6, 4.0, 3.2.14 | An issue was discovered in Django 3.2 before 3.2.14 and 4.0 before 4.0.6. The Trunc() and Extract() database functions are subject to SQL injection if untrusted data is used as a kind/lookup_name value. Applications that constrain the lookup name and kind choice to a known safe list are unaffected.
critical | react-express-mongodb/frontend/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | react-express-mongodb/frontend/package-lock.json | loader-utils | [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601) | 9.8 | fixed in 1.4.1, 2.0.3 | Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.
critical | react-express-mongodb/frontend/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | react-express-mongodb/frontend/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | react-express-mysql/frontend/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | react-express-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601) | 9.8 | fixed in 1.4.1, 2.0.3 | Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.
critical | react-express-mysql/frontend/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | react-express-mysql/frontend/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | react-java-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601) | 9.8 | fixed in 1.4.1, 2.0.3 | Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.
critical | react-java-mysql/frontend/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | react-java-mysql/frontend/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | react-java-mysql/frontend/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | react-rust-postgres/frontend/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | react-rust-postgres/frontend/package-lock.json | loader-utils | [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601) | 9.8 | fixed in 1.4.1, 2.0.3 | Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.
critical | react-rust-postgres/frontend/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | react-rust-postgres/frontend/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | react-express-mongodb/backend/package-lock.json | mongoose | [CVE-2023-3696](https://nvd.nist.gov/vuln/detail/CVE-2023-3696) | 9.8 | fixed in 7.3.4, 6.11.3, 5.13.20 | Prototype Pollution in GitHub repository automattic/mongoose prior to 7.3.4.
critical | react-express-mongodb/backend/package-lock.json | mongoose | [CVE-2022-2564](https://nvd.nist.gov/vuln/detail/CVE-2022-2564) | 9.8 | fixed in 6.4.6 | Prototype Pollution in GitHub repository automattic/mongoose prior to 6.4.6.
critical | react-nginx/package-lock.json | loader-utils | [CVE-2022-37601](https://nvd.nist.gov/vuln/detail/CVE-2022-37601) | 9.8 | fixed in 1.4.1, 2.0.3 | Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.
critical | react-nginx/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | react-nginx/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | react-nginx/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | angular/angular/package-lock.json | webpack | [CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154) | 9.8 | fixed in 5.76.0 | Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.
critical | angular/angular/package-lock.json | @babel/traverse | [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) | 9.3 | fixed in 8.0.0-alpha.4, 7.23.2 | Babel is a compiler for writingJavaScript. In `@babel/traverse` prior to versions 7.23.2 and 8.0.0-alpha.4 and all versions of `babel-traverse`, using Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods. Known affected plugins are `@babel/plugin-transform-runtime`; `@babel/preset-env` when using its `useBuiltIns` option; and any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`. No other plugins under the `@babel/` namespace are impacted, but third-party plugins might be. Users that only compile trusted code are not impacted. The vulnerability has been fixed in `@babel/traverse@7.23.2` and `@babel/traverse@8.0.0-alpha.4`. Those who cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above should upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions: `@babel/plugin-transform-runtime` v7.23.2, `@babel/preset-env` v7.23.2, `@babel/helper-define-polyfill-provider` v0.4.3, `babel-plugin-polyfill-corejs2` v0.4.6, `babel-plugin-polyfill-c
critical | angular/angular/package-lock.json | socket.io-parser | [CVE-2022-2421](https://nvd.nist.gov/vuln/detail/CVE-2022-2421) | 9.8 | fixed in 4.0.5 | Due to improper type validation in attachment parsing the Socket.io js library, it is possible to overwrite the _placeholder object which allows an attacker to place references to functions at arbitrary places in the resulting query object.  
high | nginx-wsgi-flask/flask/requirements.txt | flask | [CVE-2023-30861](https://nvd.nist.gov/vuln/detail/CVE-2023-30861) | 7.5 | fixed in 2.3.2, 2.2.5 | Flask is a lightweight WSGI web application framework. When all of the following conditions are met, a response containing data intended for one client may be cached and subsequently sent by the proxy to other clients. If the proxy also caches `Set-Cookie` headers, it may send one client\'s `session` cookie to other clients. The severity depends on the application\'s use of the session and the proxy\'s behavior regarding cookies. The risk depends on all these conditions being met.  1. The application must be hosted behind a caching proxy that does not strip cookies or ignore responses with cookies. 2. The application sets `session.permanent = True` 3. The application does not access or modify the session at any point during a request. 4. `SESSION_REFRESH_EACH_REQUEST` enabled (the default). 5. The application does not set a `Cache-Control` header to indicate that a page is private or should not be cached.  This happens because vulnerable versions of Flask only set the `Vary: Cookie` header when the session is accessed or modified, not when it is refreshed (re-sent to update the expiration) without being accessed or modified. This issue has been fixed in versions 2.3.2 and 2.2.5.
high | django/app/requirements.txt | django | [CVE-2023-36053](https://nvd.nist.gov/vuln/detail/CVE-2023-36053) | 7.5 | fixed in 4.2.3, 4.1.10, 3.2.20 | In Django 3.2 before 3.2.20, 4 before 4.1.10, and 4.2 before 4.2.3, EmailValidator and URLValidator are subject to a potential ReDoS (regular expression denial of service) attack via a very large number of domain name labels of emails and URLs.
high | django/app/requirements.txt | django | [CVE-2023-24580](https://nvd.nist.gov/vuln/detail/CVE-2023-24580) | 7.5 | fixed in 4.1.7, 4.0.10, 3.2.18 | An issue was discovered in the Multipart Request Parser in Django 3.2 before 3.2.18, 4.0 before 4.0.10, and 4.1 before 4.1.7. Passing certain inputs (e.g., an excessive number of parts) to multipart forms could result in too many open files or memory exhaustion, and provided a potential vector for a denial-of-service attack.
high | django/app/requirements.txt | django | [CVE-2023-23969](https://nvd.nist.gov/vuln/detail/CVE-2023-23969) | 7.5 | fixed in 4.1.6, 4.0.9, 3.2.17 | In Django 3.2 before 3.2.17, 4.0 before 4.0.9, and 4.1 before 4.1.6, the parsed values of Accept-Language headers are cached in order to avoid repetitive parsing. This leads to a potential denial-of-service vector via excessive memory usage if the raw value of Accept-Language headers is very large.
high | django/app/requirements.txt | django | [CVE-2022-41323](https://nvd.nist.gov/vuln/detail/CVE-2022-41323) | 7.5 | fixed in 4.1.2, 4.0.8, 3.2.16 | In Django 3.2 before 3.2.16, 4.0 before 4.0.8, and 4.1 before 4.1.2, internationalized URLs were subject to a potential denial of service attack via the locale parameter, which is treated as a regular expression.
high | django/app/requirements.txt | django | [CVE-2022-36359](https://nvd.nist.gov/vuln/detail/CVE-2022-36359) | 8.8 | fixed in 4.0.7, 4.0, 3.2.15 | An issue was discovered in the HTTP FileResponse class in Django 3.2 before 3.2.15 and 4.0 before 4.0.7. An application is vulnerable to a reflected file download (RFD) attack that sets the Content-Disposition header of a FileResponse when the filename is derived from user-supplied input.
high | django/app/requirements.txt | django | [CVE-2023-46695](https://nvd.nist.gov/vuln/detail/CVE-2023-46695) | 7.5 | fixed in 4.2.7, 4.1.13, 3.2.23 | An issue was discovered in Django 3.2 before 3.2.23, 4.1 before 4.1.13, and 4.2 before 4.2.7. The NFKC normalization is slow on Windows. As a consequence, django.contrib.auth.forms.UsernameField is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.
high | django/app/requirements.txt | django | [CVE-2023-41164](https://nvd.nist.gov/vuln/detail/CVE-2023-41164) | 7.5 | fixed in 4.2.5, 4.1.11, 3.2.21 | In Django 3.2 before 3.2.21, 4.1 before 4.1.11, and 4.2 before 4.2.5, django.utils.encoding.uri_to_iri() is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.
high | django/app/requirements.txt | django | [CVE-2023-43665](https://nvd.nist.gov/vuln/detail/CVE-2023-43665) | 7.5 | fixed in 4.2.6, 4.1.12, 3.2.22 | In Django 3.2 before 3.2.22, 4.1 before 4.1.12, and 4.2 before 4.2.6, the django.utils.text.Truncator chars() and words() methods (when used with html=True) are subject to a potential DoS (denial of service) attack via certain inputs with very long, potentially malformed HTML text. The chars() and words() methods are used to implement the truncatechars_html and truncatewords_html template filters, which are thus also vulnerable. NOTE: this issue exists because of an incomplete fix for CVE-2019-14232.
high | react-express-mongodb/frontend/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | react-express-mongodb/frontend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-express-mongodb/frontend/package-lock.json | nth-check | [CVE-2021-3803](https://nvd.nist.gov/vuln/detail/CVE-2021-3803) | 7.5 | fixed in 2.0.1 | nth-check is vulnerable to Inefficient Regular Expression Complexity
high | react-express-mongodb/frontend/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | react-express-mongodb/frontend/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | react-express-mongodb/frontend/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | react-express-mongodb/frontend/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | react-express-mongodb/frontend/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | react-express-mysql/frontend/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | react-express-mysql/frontend/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | react-express-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | react-express-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | react-express-mysql/frontend/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | react-express-mysql/frontend/package-lock.json | nth-check | [CVE-2021-3803](https://nvd.nist.gov/vuln/detail/CVE-2021-3803) | 7.5 | fixed in 2.0.1 | nth-check is vulnerable to Inefficient Regular Expression Complexity
high | react-express-mysql/frontend/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | react-express-mysql/frontend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-java-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | react-java-mysql/frontend/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | react-java-mysql/frontend/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | react-java-mysql/frontend/package-lock.json | nth-check | [CVE-2021-3803](https://nvd.nist.gov/vuln/detail/CVE-2021-3803) | 7.5 | fixed in 2.0.1 | nth-check is vulnerable to Inefficient Regular Expression Complexity
high | react-java-mysql/frontend/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | react-java-mysql/frontend/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | react-java-mysql/frontend/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | react-java-mysql/frontend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-rust-postgres/frontend/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | react-rust-postgres/frontend/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | react-rust-postgres/frontend/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | react-rust-postgres/frontend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-rust-postgres/frontend/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | react-rust-postgres/frontend/package-lock.json | nth-check | [CVE-2021-3803](https://nvd.nist.gov/vuln/detail/CVE-2021-3803) | 7.5 | fixed in 2.0.1 | nth-check is vulnerable to Inefficient Regular Expression Complexity
high | react-rust-postgres/frontend/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | react-rust-postgres/frontend/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | react-express-mysql/backend/package-lock.json | http-cache-semantics | [CVE-2022-25881](https://nvd.nist.gov/vuln/detail/CVE-2022-25881) | 7.5 | fixed in 4.1.1 | This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\r\r
high | react-express-mysql/backend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-express-mysql/backend/package-lock.json | cookiejar | [CVE-2022-25901](https://nvd.nist.gov/vuln/detail/CVE-2022-25901) | 7.5 | fixed in 2.1.4 | Versions of the package cookiejar before 2.1.4 are vulnerable to Regular Expression Denial of Service (ReDoS) via the Cookie.parse function, which uses an insecure regular expression.\r\r
high | react-express-mysql/backend/package-lock.json | mocha | [PRISMA-2022-0230](https://github.com/mochajs/mocha/pull/4770) | 7.5 | fixed in 10.1.0 | org.webjars.npm_mocha packages from all versions are vulnerable to Regular Expression Denial of Service (ReDoS). clean() function is vulnerable to ReDoS attack due to the overlapped sub-patterns.
high | react-express-mysql/backend/package-lock.json | qs | [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) | 7.5 | fixed in 6.10.3 | qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).
high | react-express-mysql/backend/package-lock.json | minimatch | [CVE-2022-3517](https://nvd.nist.gov/vuln/detail/CVE-2022-3517) | 7.5 | fixed in 3.0.5 | A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service.
high | react-express-mysql/backend/package-lock.json | get-func-name | [CVE-2023-43646](https://nvd.nist.gov/vuln/detail/CVE-2023-43646) | 7.5 | fixed in 2.0.1 | get-func-name is a module to retrieve a function\'s name securely and consistently both in NodeJS and the browser. Versions prior to 2.0.1 are subject to a regular expression denial of service (redos) vulnerability which may lead to a denial of service when parsing malicious input. This vulnerability can be exploited when there is an imbalance in parentheses, which results in excessive backtracking and subsequently increases the CPU load and processing time significantly. This vulnerability can be triggered using the following input: \'\\t\'.repeat(54773) + \'\\t/function/i\'. This issue has been addressed in commit `f934b228b` which has been included in releases from 2.0.1. Users are advised to upgrade. There are no known workarounds for this vulnerability.
high | react-express-mongodb/backend/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-express-mongodb/backend/package-lock.json | http-cache-semantics | [CVE-2022-25881](https://nvd.nist.gov/vuln/detail/CVE-2022-25881) | 7.5 | fixed in 4.1.1 | This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\r\r
high | react-express-mongodb/backend/package-lock.json | minimatch | [CVE-2022-3517](https://nvd.nist.gov/vuln/detail/CVE-2022-3517) | 7.5 | fixed in 3.0.5 | A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service.
high | react-express-mongodb/backend/package-lock.json | moment | [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/CVE-2022-31129) | 7.5 | fixed in 2.29.4 | moment is a JavaScript date library for parsing, validating, manipulating, and formatting dates. Affected versions of moment were found to use an inefficient parsing algorithm. Specifically using string-to-date parsing in moment (more specifically rfc2822 parsing, which is tried by default) has quadratic (N^2) complexity on specific inputs. Users may notice a noticeable slowdown is observed with inputs above 10k characters. Users who pass user-provided strings without sanity length checks to moment constructor are vulnerable to (Re)DoS attacks. The problem is patched in 2.29.4, the patch can be applied to all affected versions with minimal tweaking. Users are advised to upgrade. Users unable to upgrade should consider limiting date lengths accepted from user input.
high | react-express-mongodb/backend/package-lock.json | qs | [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) | 7.5 | fixed in 6.10.3 | qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).
high | react-nginx/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | react-nginx/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | react-nginx/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | react-nginx/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | react-nginx/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | react-nginx/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | react-nginx/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | react-nginx/package-lock.json | nth-check | [CVE-2021-3803](https://nvd.nist.gov/vuln/detail/CVE-2021-3803) | 7.5 | fixed in 2.0.1 | nth-check is vulnerable to Inefficient Regular Expression Complexity
high | angular/angular/package-lock.json | minimatch | [CVE-2022-3517](https://nvd.nist.gov/vuln/detail/CVE-2022-3517) | 7.5 | fixed in 3.0.5 | A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service.
high | angular/angular/package-lock.json | loader-utils | [CVE-2022-37599](https://nvd.nist.gov/vuln/detail/CVE-2022-37599) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.
high | angular/angular/package-lock.json | loader-utils | [CVE-2022-37603](https://nvd.nist.gov/vuln/detail/CVE-2022-37603) | 7.5 | fixed in 3.2.1, 2.0.4, 1.4.2 | A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.
high | angular/angular/package-lock.json | json5 | [CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175) | 8.8 | fixed in 2.2.2, 1.0.2 | JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 ver
high | angular/angular/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | angular/angular/package-lock.json | decode-uri-component | [CVE-2022-38900](https://nvd.nist.gov/vuln/detail/CVE-2022-38900) | 7.5 | fixed in 0.2.1 | decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.
high | angular/angular/package-lock.json | http-cache-semantics | [CVE-2022-25881](https://nvd.nist.gov/vuln/detail/CVE-2022-25881) | 7.5 | fixed in 4.1.1 | This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.\r\r
high | angular/angular/package-lock.json | terser | [CVE-2022-25858](https://nvd.nist.gov/vuln/detail/CVE-2022-25858) | 7.5 | fixed in 5.14.2, 4.8.1 | The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.
high | angular/angular/package-lock.json | ua-parser-js | [CVE-2022-25927](https://nvd.nist.gov/vuln/detail/CVE-2022-25927) | 7.5 | fixed in 1.0.33, 0.7.33 | Versions of the package ua-parser-js from 0.7.30 and before 0.7.33, from 0.8.1 and before 1.0.33 are vulnerable to Regular Expression Denial of Service (ReDoS) via the trim() function.\r\r
high | angular/angular/package-lock.json | socket.io-parser | [CVE-2023-32695](https://nvd.nist.gov/vuln/detail/CVE-2023-32695) | 7.5 | fixed in 4.2.3, 3.4.3 | socket.io parser is a socket.io encoder and decoder written in JavaScript complying with version 5 of socket.io-protocol. A specially crafted Socket.IO packet can trigger an uncaught exception on the Socket.IO server, thus killing the Node.js process. A patch has been released in version 4.2.3.  
high | sparkjava-mysql/backend/pom.xml | com.google.code.gson_gson | [CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) | 7.7 | fixed in 2.8.9 | The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks.
medium | react-express-mongodb/frontend/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | react-express-mongodb/frontend/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | react-express-mysql/frontend/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | react-express-mysql/frontend/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | react-java-mysql/frontend/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | react-java-mysql/frontend/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | react-rust-postgres/frontend/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | react-rust-postgres/frontend/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | react-express-mysql/backend/package-lock.json | got | [CVE-2022-33987](https://nvd.nist.gov/vuln/detail/CVE-2022-33987) | 5.3 | fixed in 12.1.0 | The got package before 12.1.0 (also fixed in 11.8.5) for Node.js allows a redirect to a UNIX socket.
moderate | react-express-mongodb/backend/package-lock.json | mongodb | [CVE-2021-32050](https://nvd.nist.gov/vuln/detail/CVE-2021-32050) | 4.2 | fixed in 5.8.0, 4.17.0, 3.6.10 | Some MongoDB Drivers may erroneously publish events containing authentication-related data to a command listener configured by an application. The published events may contain security-sensitive data when specific authentication-related commands are executed.  Without due care, an application may inadvertently expose this sensitive information, e.g., by writing it to a log file. This issue only arises if an application enables the command listener feature (this is not enabled by default).  This issue affects the MongoDB C Driver 1.0.0 prior to 1.17.7, MongoDB PHP Driver 1.0.0 prior to 1.9.2, MongoDB Swift Driver 1.0.0 prior to 1.1.1, MongoDB Node.js Driver 3.6 prior to 3.6.10, MongoDB Node.js Driver 4.0 prior to 4.17.0 and MongoDB Node.js Driver 5.0 prior to 5.8.0. This issue also affects users of the MongoDB C++ Driver dependent on the C driver 1.0.0 prior to 1.17.7 (C++ driver prior to 3.7.0).  
medium | react-express-mongodb/backend/package-lock.json | got | [CVE-2022-33987](https://nvd.nist.gov/vuln/detail/CVE-2022-33987) | 5.3 | fixed in 12.1.0 | The got package before 12.1.0 (also fixed in 11.8.5) for Node.js allows a redirect to a UNIX socket.
medium | react-nginx/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | react-nginx/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | angular/angular/package-lock.json | engine.io | [CVE-2023-31125](https://nvd.nist.gov/vuln/detail/CVE-2023-31125) | 6.5 | fixed in 6.4.2 | Engine.IO is the implementation of transport-based cross-browser/cross-device bi-directional communication layer for Socket.IO. An uncaught exception vulnerability was introduced in version 5.1.0 and included in version 4.1.0 of the `socket.io` parent package. Older versions are not impacted. A specially crafted HTTP request can trigger an uncaught exception on the Engine.IO server, thus killing the Node.js process. This impacts all the users of the `engine.io` package, including those who use depending packages like `socket.io`. This issue was fixed in version 6.4.2 of Engine.IO. There is no known workaround except upgrading to a safe version. 
medium | angular/angular/package-lock.json | decode-uri-component | [CVE-2022-38778](https://nvd.nist.gov/vuln/detail/CVE-2022-38778) | 6.5 | fixed in 0.2.1 | A flaw (CVE-2022-38900) was discovered in one of Kibana’s third party dependencies, that could allow an authenticated user to perform a request that crashes the Kibana server process.
medium | angular/angular/package-lock.json | postcss | [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270) | 5.3 | fixed in 8.4.31 | An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.
medium | angular/angular/package-lock.json | istanbul-reports | [PRISMA-2022-0005](https://github.com/istanbuljs/istanbuljs/commit/4eceb9eb8b3169b882d74ecc526fb5837ebc6205) | 5.3 | fixed in 3.1.3 | istanbul-reports package versions before 3.1.3 are vulnerable to Reverse Tabnabbing. Tabnabbing - \"it\'s the capacity to act on parent page\'s content or location from a newly opened page via the backlink exposed by the opener javascript object instance.\" This vulnerability usually manifests when either The \"target\" attribute is used to specify the target location in an anchor tag to open 3rd party URL/resource(s) without including the attribute rel=\"noopener,noreferrer \" in the anchor tag.
moderate | sparkjava-mysql/backend/pom.xml | mysql_mysql-connector-java | [CVE-2022-21363](https://nvd.nist.gov/vuln/detail/CVE-2022-21363) | 6.6 | fixed in 8.0.28 | Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/J). Supported versions that are affected are 8.0.27 and prior. Difficult to exploit vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Connectors. Successful attacks of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.1 Base Score 6.6 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H).
moderate | sparkjava-mysql/backend/pom.xml | mysql_mysql-connector-java | [CVE-2021-2471](https://nvd.nist.gov/vuln/detail/CVE-2021-2471) | 5.9 | fixed in 8.0.27 | Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/J). Supported versions that are affected are 8.0.26 and prior. Difficult to exploit vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Connectors. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all MySQL Connectors accessible data and unauthorized ability to cause a hang or frequently repeatable crash (complete DOS) of MySQL Connectors. CVSS 3.1 Base Score 5.9 (Confidentiality and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:H).
